### PR TITLE
Fix next steps token count

### DIFF
--- a/main.py
+++ b/main.py
@@ -223,7 +223,7 @@ def process(input_path):
                     "content": processed_text
                 }
             ],
-            max_tokens=100000,
+            max_tokens=4096,
             temperature=0.25
         )
         next_steps = completion.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- align `next_steps` max tokens with typical LLM limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417cedeba48332968733fdda2ffd26