### PR TITLE
Fix typo in summary prompt

### DIFF
--- a/prompts/summary.system_prompt.md
+++ b/prompts/summary.system_prompt.md
@@ -1,4 +1,4 @@
-Given a health log hystory, create a structured patient summary with the following format. This summary should provide the following information:
+Given a health log history, create a structured patient summary with the following format. This summary should provide the following information:
 
 - Current symptoms/complaints/diagnoses
 - Current medications


### PR DESCRIPTION
## Summary
- update summary prompt: `hystory` -> `history`

## Testing
- `python test.py` *(fails: FileNotFoundError: No such file or directory './output/input/')*

------
https://chatgpt.com/codex/tasks/task_e_68417cf31e58833283c164a6ac525284